### PR TITLE
Make build status badge in README link to Travis build page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [ui-icon](https://github.com/lifegadget/ui-icon) ![ ](https://travis-ci.org/lifegadget/ui-icon.svg) [![npm version](https://badge.fury.io/js/ui-icon.svg)](http://badge.fury.io/js/ui-icon)  [![Code Climate](https://codeclimate.com/github/lifegadget/ui-icon/badges/gpa.svg)](https://codeclimate.com/github/lifegadget/ui-icon)
+# [ui-icon](https://github.com/lifegadget/ui-icon) [![Build Status](https://travis-ci.org/lifegadget/ui-icon.svg?branch=master)](https://travis-ci.org/lifegadget/ui-icon) [![npm version](https://badge.fury.io/js/ui-icon.svg)](http://badge.fury.io/js/ui-icon)  [![Code Climate](https://codeclimate.com/github/lifegadget/ui-icon/badges/gpa.svg)](https://codeclimate.com/github/lifegadget/ui-icon)
 > FontAwesome icons with Ember flare
 
 ## Install ##


### PR DESCRIPTION
This is a small tweak to the build status badge in the README so that it links to the Travis page for the build instead of to Github's cached version of the badge.
